### PR TITLE
`dev` branch merge

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,2 @@
-globals = {
-   "vim",
-}
+globals = {"vim"}
+max_comment_line_length = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Linting` Github Action init
-- `Makefile, .lua-format, .luacheckrc` init
-- format .lua code with (lua-format)[https://github.com/Koihik/LuaFormatter]
-- `kitty` tabs color changed
-- onedark setting using `reqiure("onedark.config")` [monsonjeremy/onedark.nvim#5]
+- **Warning** on `vim.g` configuration
+- Configure plugin in lua using `require('onedark').setup({})` **[fix monsonjeremy/onedark.nvim#5]**
+- Minimal config example added inside [README.md#minimal](./README.md#minimal)
+- Linting Github Action init
+- Format .lua code with [lua-format](https://github.com/Koihik/LuaFormatter)
+- **kitty tab** colors are changed
+- Init: `Makefile, .lua-format, .luacheckrc`
 
 ### Changed
 
+- Removed function `require('onedark').colorscheme()`
+- Colorscheme **autoload removed** from `colors/onedark.vim`
 - **VertSplit** & **Inactive StatusLine** `fg` color changed to `bg_visual`
-- configuration docs updated inside README.md
+- StatusLine bug note inside [README.md#usage](./README.md#-usage)
+- Configuration docs updated inside [README.md#configuration](./README.md#-configuration)
 
 ## [v0.0.1] - 14 June 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Makefile, .lua-format, .luacheckrc` init
 - format .lua code with (lua-format)[https://github.com/Koihik/LuaFormatter]
 - `kitty` tabs color changed
+- onedark setting using `reqiure("onedark.config")` [monsonjeremy/onedark.nvim#5]
 
 ### Changed
 
 - **VertSplit** & **Inactive StatusLine** `fg` color changed to `bg_visual`
+- configuration docs updated inside README.md
 
 ## [v0.0.1] - 14 June 2021
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ format:
 	@for file in `find . -name '*.lua'`;do lua-format $$file -i; done;
 
 lint: $(onedark_path)
-	@luacheck $(onedark_path)
+	@luacheck $(onedark_path) --config .luacheckrc
 
 check: format lint

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ format:
 	@for file in `find . -name '*.lua'`;do lua-format $$file -i; done;
 
 lint: $(onedark_path)
-	@luacheck $(onedark_path) --config .luacheckrc
+	@luacheck $(onedark_path)
 
 check: format lint

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
+<!-- Branding -->
 <p align="center">
-    <img src="https://i.imgur.com/lNdBu1v.png" alt="onedark.nvim" />
+  <img src="https://i.imgur.com/lNdBu1v.png" alt="onedark.nvim" />
+  <br />
+  Atom's iconic One Dark theme for Neovim, written in Lua
 </p>
 
+<!-- Badges -->
 <p align="center">
-    Atom's iconic One Dark theme for Neovim, written in Lua
-</p>
-
-<p align="center">
-    De-attach fork of <b><a href="https://github.com/monsonjeremy/onedark.nvim">monsonjeremy/onedark.nvim</a></b>
+  <!-- First Row -->
+  <a href="https://github.com/monsonjeremy/onedark.nvim">
+    <img alt="monsonjeremy/onedark.nvim" src="https://img.shields.io/badge/Fork%20of-monsonjeremy%2Fonedark.nvim-blue" />
+  </a>
+  <a href="https://github.com/ful1e5/onedark.nvim/actions">
+    <img alt="GitHub Action Linting" src="https://github.com/ful1e5/onedark.nvim/actions/workflows/lint.yml/badge.svg" width="102" />
+  </a>
 </p>
 
 ## ✨ Features
@@ -151,7 +157,7 @@ set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{25
 
 ## 🌈 Extras
 
-> To generate the configs `:luafile /lua/onedark/extra/init.lua`
+> To generate the configs `make extra`
 
 Extra color configs for **Kitty**, and **Alacritty** can be found in [extras](extras/). To use them, refer to their respective documentation.
 
@@ -205,6 +211,21 @@ require("onedark").setup({
     <img src="https://imgur.com/oA5PjUb.png" alt="Italic fonts" />
 </p>
 
+### Minimal
+
+```lua
+require("onedark").setup({
+  hideInactiveStatusline = true,
+  darkSidebar = false,
+  darkFloat = false
+  -- ... your onedark config
+})
+```
+
+<p align="center">
+    <img src="https://imgur.com/VSTW3Hr.png" alt="Minimal" />
+</p>
+
 ### Telescope
 
 <p align="center">
@@ -218,8 +239,6 @@ require("onedark").setup({
 - [Wallpaper](https://hdqwalls.com/big-sur-4k-wallpaper)
 - [dotfiles](https://github.com/ful1e5/dotfiles)
 
-<!-- Support -->
-
 ## Support
 
 <a href="https://www.buymeacoffee.com/Nt7Wg4V" >
@@ -231,7 +250,6 @@ require("onedark").setup({
 Follow me on **[Twitter](https://twitter.com/ful1e5)**
 
 <!-- Ninja  -->
-
 <p align="center">
   <h1 align="center">(◣_◢)</h1>
 </p>

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ vim.g.lightline = {colorscheme = "onedark"}
 
 | Option                 | Default | Description                                                                                                                                                     |
 | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| commentStyle           | `true`  | Make comments italic                                                                                                                                            |
-| keywordStyle           | `true`  | Make keywords italic                                                                                                                                            |
-| functionStyle          | `false` | Make functions italic                                                                                                                                           |
-| variableStyle          | `false` | Make variables and identifiers italic                                                                                                                           |
+| commentStyle           | `NONE`  | Make comments italic **(Options:** `NONE` or `Italic`)                                                                                                          |
+| keywordStyle           | `NONE`  | Make keywords italic **(Options:** `NONE` or `Italic`)                                                                                                          |
+| functionStyle          | `NONE`  | Make functions italic **(Options:** `NONE` or `Italic`)                                                                                                         |
+| variableStyle          | `NONE`  | Make variables and identifiers italic **(Options:** `NONE` or `Italic`)                                                                                         |
 | transparent            | `false` | Enable this to disable setting the background color                                                                                                             |
 | hideInactiveStatusline | `false` | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
-| sidebars               | `{}`    | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
+| sidebars               | `{}`    | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
 | darkSidebar            | `true`  | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
 | darkFloat              | `true`  | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
 | colors                 | `{}`    | You can override specific color groups to use other groups or a hex color                                                                                       |
@@ -175,10 +175,10 @@ Extra color configs for **Kitty**, and **Alacritty** can be found in [extras](ex
 
 ```lua
 require("onedark").setup({
-  commentStyle = false,
-  keywordStyle = false,
-  functionStyle = false,
-  variableStyle = false,
+  commentStyle = "NONE",
+  keywordStyle = "NONE",
+  functionStyle = "NONE",
+  variableStyle = "NONE"
   -- ... your onedark config
 })
 ```
@@ -191,10 +191,10 @@ require("onedark").setup({
 
 ```lua
 require("onedark").setup({
-  commentStyle = true,
-  keywordStyle = true,
-  functionStyle = true,
-  variableStyle = true,
+  commentStyle = "Italic",
+  keywordStyle = "Italic",
+  functionStyle = "Italic",
+  variableStyle = "Italic"
   -- ... your onedark config
 })
 ```

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Enable the colorscheme:
 
 ```vim
 " Vim Script
-colorscheme onedark
+lua require('onedark').setup()
 ```
 
 ```lua
 -- Lua
-vim.cmd[[colorscheme onedark]]
+require('onedark').setup()
 ```
 
 To enable the `onedark` theme for `Lualine`, simply specify it in your lualine settings:
@@ -92,42 +92,48 @@ To enable the `onedark` colorscheme for `Lightline`:
 let g:lightline = {'colorscheme': 'onedark'}
 ```
 
+```lua
+-- Lua
+vim.g.lightline = {colorscheme = "onedark"}
+```
+
 ## ⚙️ Configuration
 
-> ❗️ configuration needs to be set **BEFORE** loading the color scheme with `colorscheme onedark`
-
-| Option                           | Default | Description                                                                                                                                                     |
-| -------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| onedark_italic_comments          | `true`  | Make comments italic                                                                                                                                            |
-| onedark_italic_keywords          | `true`  | Make keywords italic                                                                                                                                            |
-| onedark_italic_functions         | `false` | Make functions italic                                                                                                                                           |
-| onedark_italic_variables         | `false` | Make variables and identifiers italic                                                                                                                           |
-| onedark_transparent              | `false` | Enable this to disable setting the background color                                                                                                             |
-| onedark_hide_inactive_statusline | `false` | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
-| onedark_sidebars                 | `{}`    | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
-| onedark_dark_sidebar             | `true`  | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
-| onedark_dark_float               | `true`  | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
-| onedark_colors                   | `{}`    | You can override specific color groups to use other groups or a hex color                                                                                       |
+| Option                 | Default | Description                                                                                                                                                     |
+| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| commentStyle           | `true`  | Make comments italic                                                                                                                                            |
+| keywordStyle           | `true`  | Make keywords italic                                                                                                                                            |
+| functionStyle          | `false` | Make functions italic                                                                                                                                           |
+| variableStyle          | `false` | Make variables and identifiers italic                                                                                                                           |
+| transparent            | `false` | Enable this to disable setting the background color                                                                                                             |
+| hideInactiveStatusline | `false` | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
+| sidebars               | `{}`    | Set a darker background on sidebar-like windows. For example: `["qf", "vista_kind", "terminal", "packer"]`                                                      |
+| darkSidebar            | `true`  | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
+| darkFloat              | `true`  | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
+| colors                 | `{}`    | You can override specific color groups to use other groups or a hex color                                                                                       |
 
 ```lua
 -- Example config in Lua
-vim.g.onedark_italic_functions = true
-vim.g.onedark_sidebars = { "qf", "vista_kind", "terminal", "packer" }
+require("onedark").setup({
+  functionStyle = true,
+  sidebars = {"qf", "vista_kind", "terminal", "packer"},
 
--- Change the "hint" color to the "orange" color, and make the "error" color bright red
-vim.g.onedark_colors = { hint = "orange", error = "#ff0000" }
-
--- Load the colorscheme
-vim.cmd[[colorscheme onedark]]
+  -- Change the "hint" color to the "orange" color, and make the "error" color bright red
+  colors = {hint = "orange", error = "#ff0000"}
+})
 ```
 
 ```vim
 " Example config in VimScript
-let g:onedark_italic_functions = 1
-let g:onedark_sidebars = [ "qf", "vista_kind", "terminal", "packer" ]
+lua << EOF
+require("onedark").setup({
+  functionStyle = true,
+  sidebars = {"qf", "vista_kind", "terminal", "packer"},
 
-" Load the colorscheme
-colorscheme onedark
+  -- Change the "hint" color to the "orange" color, and make the "error" color bright red
+  colors = {hint = "orange", error = "#ff0000"}
+})
+EOF
 ```
 
 ### Making `undercurls` work properly in **Tmux**
@@ -167,11 +173,14 @@ Extra color configs for **Kitty**, and **Alacritty** can be found in [extras](ex
 
 ### Normal
 
-```
-vim.g.onedark_italic_comments = false
-vim.g.onedark_italic_keywords = false
-vim.g.onedark_italic_functions = false
-vim.g.onedark_italic_variables = false
+```lua
+require("onedark").setup({
+  commentStyle = false,
+  keywordStyle = false,
+  functionStyle = false,
+  variableStyle = false,
+  -- ... your onedark config
+})
 ```
 
 <p align="center">
@@ -180,11 +189,14 @@ vim.g.onedark_italic_variables = false
 
 ### Italic
 
-```
-vim.g.onedark_italic_comments = true
-vim.g.onedark_italic_keywords = true
-vim.g.onedark_italic_functions = true
-vim.g.onedark_italic_variables = true
+```lua
+require("onedark").setup({
+  commentStyle = true,
+  keywordStyle = true,
+  functionStyle = true,
+  variableStyle = true,
+  -- ... your onedark config
+})
 ```
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ vim.g.lightline = {colorscheme = "onedark"}
 
 | Option                 | Default | Description                                                                                                                                                     |
 | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| commentStyle           | `NONE`  | Make comments italic **(Options:** `NONE` or `Italic`)                                                                                                          |
-| keywordStyle           | `NONE`  | Make keywords italic **(Options:** `NONE` or `Italic`)                                                                                                          |
-| functionStyle          | `NONE`  | Make functions italic **(Options:** `NONE` or `Italic`)                                                                                                         |
-| variableStyle          | `NONE`  | Make variables and identifiers italic **(Options:** `NONE` or `Italic`)                                                                                         |
+| commentStyle           | `NONE`  | Make comments italic **(Options:** `NONE` or `italic`)                                                                                                          |
+| keywordStyle           | `NONE`  | Make keywords italic **(Options:** `NONE` or `italic`)                                                                                                          |
+| functionStyle          | `NONE`  | Make functions italic **(Options:** `NONE` or `italic`)                                                                                                         |
+| variableStyle          | `NONE`  | Make variables and identifiers italic **(Options:** `NONE` or `italic`)                                                                                         |
 | transparent            | `false` | Enable this to disable setting the background color                                                                                                             |
 | hideInactiveStatusline | `false` | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
 | sidebars               | `{}`    | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
@@ -115,7 +115,7 @@ vim.g.lightline = {colorscheme = "onedark"}
 ```lua
 -- Example config in Lua
 require("onedark").setup({
-  functionStyle = true,
+  functionStyle = "italic",
   sidebars = {"qf", "vista_kind", "terminal", "packer"},
 
   -- Change the "hint" color to the "orange" color, and make the "error" color bright red
@@ -127,7 +127,7 @@ require("onedark").setup({
 " Example config in VimScript
 lua << EOF
 require("onedark").setup({
-  functionStyle = true,
+  functionStyle = "italic",
   sidebars = {"qf", "vista_kind", "terminal", "packer"},
 
   -- Change the "hint" color to the "orange" color, and make the "error" color bright red

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ require('onedark').setup()
 
 To enable the `onedark` theme for `Lualine`, simply specify it in your lualine settings:
 
+> **📝 NOTE:** Set `lualine` configuration **before** `onedark`.
+
 ```lua
 require('lualine').setup {
   options = {
@@ -99,18 +101,18 @@ vim.g.lightline = {colorscheme = "onedark"}
 
 ## ⚙️ Configuration
 
-| Option                 | Default | Description                                                                                                                                                     |
-| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| commentStyle           | `NONE`  | Make comments italic **(Options:** `NONE` or `italic`)                                                                                                          |
-| keywordStyle           | `NONE`  | Make keywords italic **(Options:** `NONE` or `italic`)                                                                                                          |
-| functionStyle          | `NONE`  | Make functions italic **(Options:** `NONE` or `italic`)                                                                                                         |
-| variableStyle          | `NONE`  | Make variables and identifiers italic **(Options:** `NONE` or `italic`)                                                                                         |
-| transparent            | `false` | Enable this to disable setting the background color                                                                                                             |
-| hideInactiveStatusline | `false` | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
-| sidebars               | `{}`    | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
-| darkSidebar            | `true`  | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
-| darkFloat              | `true`  | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
-| colors                 | `{}`    | You can override specific color groups to use other groups or a hex color                                                                                       |
+| Option                 | Default  | Description                                                                                                                                                     |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| commentStyle           | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                                         |
+| keywordStyle           | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                         |
+| functionStyle          | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
+| variableStyle          | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
+| transparent            | `false`  | Enable this to disable setting the background color                                                                                                             |
+| hideInactiveStatusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
+| sidebars               | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
+| darkSidebar            | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
+| darkFloat              | `true`   | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
+| colors                 | `{}`     | You can override specific color groups to use other groups or a hex color                                                                                       |
 
 ```lua
 -- Example config in Lua
@@ -191,10 +193,10 @@ require("onedark").setup({
 
 ```lua
 require("onedark").setup({
-  commentStyle = "Italic",
-  keywordStyle = "Italic",
-  functionStyle = "Italic",
-  variableStyle = "Italic"
+  commentStyle = "italic",
+  keywordStyle = "italic",
+  functionStyle = "italic",
+  variableStyle = "italic"
   -- ... your onedark config
 })
 ```

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -5,5 +5,3 @@ lua package.loaded['onedark.theme'] = nil
 lua package.loaded['onedark.colors'] = nil
 lua package.loaded['onedark.util'] = nil
 lua package.loaded['onedark.config'] = nil
-
-" lua require('onedark').setup()

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -6,4 +6,4 @@ lua package.loaded['onedark.colors'] = nil
 lua package.loaded['onedark.util'] = nil
 lua package.loaded['onedark.config'] = nil
 
-lua require('onedark').colorscheme()
+lua require('onedark').setup()

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -6,4 +6,4 @@ lua package.loaded['onedark.colors'] = nil
 lua package.loaded['onedark.util'] = nil
 lua package.loaded['onedark.config'] = nil
 
-lua require('onedark').setup()
+" lua require('onedark').setup()

--- a/extras/alacritty_onedark_.yml
+++ b/extras/alacritty_onedark_.yml
@@ -30,5 +30,3 @@ colors:
   indexed_colors:
     - { index: 16, color: '0xd19a66' }
     - { index: 17, color: '0xf65866' }
-    
-  

--- a/extras/kitty_onedark_.conf
+++ b/extras/kitty_onedark_.conf
@@ -1,40 +1,39 @@
-  # onedark colors for Kitty
-  
-  background #282c34
-  foreground #abb2bf
-  selection_background #393f4a
-  selection_foreground #abb2bf
-  url_color #98c379
-  cursor #abb2bf
-  
-  # Tabs
-  active_tab_background #61afef
-  active_tab_foreground #282c34
-  inactive_tab_background #abb2bf
-  inactive_tab_foreground #282c34
-  #tab_bar_background #20232A
-  
-  # normal
-  color0 #20232A
-  color1 #e86671
-  color2 #98c379
-  color3 #e0af68
-  color4 #61afef
-  color5 #c678dd
-  color6 #56b6c2
-  color7 #798294
-  
-  # bright
-  color8 #5c6370
-  color9 #e86671
-  color10 #98c379
-  color11 #e0af68
-  color12 #61afef
-  color13 #c678dd
-  color14 #56b6c2
-  color15 #abb2bf
-  
-  # extended colors
-  color16 #d19a66
-  color17 #f65866
-  
+# onedark colors for Kitty
+
+background #282c34
+foreground #abb2bf
+selection_background #393f4a
+selection_foreground #abb2bf
+url_color #98c379
+cursor #abb2bf
+
+# Tabs
+active_tab_background #61afef
+active_tab_foreground #282c34
+inactive_tab_background #abb2bf
+inactive_tab_foreground #282c34
+#tab_bar_background #20232A
+
+# normal
+color0 #20232A
+color1 #e86671
+color2 #98c379
+color3 #e0af68
+color4 #61afef
+color5 #c678dd
+color6 #56b6c2
+color7 #798294
+
+# bright
+color8 #5c6370
+color9 #e86671
+color10 #98c379
+color11 #e0af68
+color12 #61afef
+color13 #c678dd
+color14 #56b6c2
+color15 #abb2bf
+
+# extended colors
+color16 #d19a66
+color17 #f65866

--- a/lua/lualine/themes/onedark.lua
+++ b/lua/lualine/themes/onedark.lua
@@ -1,5 +1,5 @@
-local config = require("onedark.config")
-local colors = require("onedark.colors").setup(config)
+local configModule = require("onedark.config")
+local colors = require("onedark.colors").setup(configModule.config)
 
 local onedark = {}
 

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -10,9 +10,7 @@ function M.setup(config)
 
   -- Color Palette
   ---@class ColorScheme
-  local colors = {}
-
-  colors = {
+  local colors = {
     none = "NONE",
     bg = "#282c34",
     bg2 = "#21252b",

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -1,11 +1,12 @@
 local util = require("onedark.util")
+local configModule = require("onedark.config")
 
 local M = {}
 
 ---@param config Config
 ---@return ColorScheme
 function M.setup(config)
-  config = config or require("onedark.config")
+  config = config or configModule.config
 
   -- Color Palette
   ---@class ColorScheme

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -5,25 +5,49 @@ local config
 vim = vim or {g = {}, o = {}}
 
 local function opt(key, default)
-  key = "onedark_" .. key
   if vim.g[key] == nil then return default end
   if vim.g[key] == 0 then return false end
   return vim.g[key]
 end
 
+local g = {
+  transparent = "onedark_transparent",
+  commentStyle = "onedark_italic_comments",
+  keywordStyle = "onedark_italic_keywords",
+  functionStyle = "onedark_italic_functions",
+  variableStyle = "onedark_italic_variables",
+  hideInactiveStatusline = "onedark_hide_inactive_statusline",
+  sidebars = "onedark_sidebars",
+  colors = "onedark_colors",
+  dev = "onedark_dev",
+  darkFloat = "onedark_dark_float",
+  darkSidebar = "onedark_dark_sidebar"
+}
+
 config = {
-  transparent = opt("transparent", false),
-  commentStyle = opt("italic_comments", true) and "italic" or "NONE",
-  keywordStyle = opt("italic_keywords", true) and "italic" or "NONE",
-  functionStyle = opt("italic_functions", false) and "italic" or "NONE",
-  variableStyle = opt("italic_variables", false) and "italic" or "NONE",
-  hideInactiveStatusline = opt("hide_inactive_statusline", false),
-  sidebars = opt("sidebars", {}),
-  colors = opt("colors", {}),
-  dev = opt("dev", false),
-  darkFloat = opt("dark_float", true),
-  darkSidebar = opt("dark_sidebar", true),
+  transparent = opt(g.transparent, false),
+  commentStyle = opt(g.commentStyle, true) and "italic" or "NONE",
+  keywordStyle = opt(g.keywordStyle, true) and "italic" or "NONE",
+  functionStyle = opt(g.functionStyle, false) and "italic" or "NONE",
+  variableStyle = opt(g.variableStyle, false) and "italic" or "NONE",
+  hideInactiveStatusline = opt(g.hideInactiveStatusline, false),
+  sidebars = opt(g.sidebars, {}),
+  colors = opt(g.colors, {}),
+  dev = opt(g.dev, false),
+  darkFloat = opt(g.darkFloat, true),
+  darkSidebar = opt(g.darkSidebar, true),
   transform_colors = false
 }
 
-return config
+local function isGlobals()
+  for key, gKey in pairs(g) do
+    if vim.g[gKey] ~= nil and vim.g[gKey] ~= config[key] then return true end
+  end
+  return false
+end
+
+local function applyConfiguration(userConfig)
+  for key, value in pairs(userConfig) do config[key] = value end
+end
+
+return {config = config, isGlobals = isGlobals, applyConfiguration = applyConfiguration}

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -33,7 +33,15 @@ config = {
 }
 
 local function applyConfiguration(userConfig)
-  for key, value in pairs(userConfig) do config[key] = value end
+  for key, value in pairs(userConfig) do
+    if config[key] ~= nil then
+      config[key] = value
+    else
+      vim.schedule(function()
+        vim.api.nvim_err_writeln("ful1e5/onedark: Unable to set option '" .. key .. "'") -- luacheck: ignore
+      end)
+    end
+  end
 end
 
 return {config = config, vimConfig = vimConfig, applyConfiguration = applyConfiguration}

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -8,13 +8,16 @@ vim = vim or {g = {}, o = {}}
 
 local function opt(key, default)
   key = "onedark_" .. key
-  if vim.g[key] == nil then return default end
-  if vim.g[key] == 0 then
+  if vim.g[key] == nil then
+    return default
+  else
     vimConfig = true
-    return false
+    if vim.g[key] == 0 then
+      return false
+    else
+      return vim.g[key]
+    end
   end
-  vimConfig = true
-  return vim.g[key]
 end
 
 config = {

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -1,53 +1,39 @@
 ---@class Config
 local config
 
+local vimConfig = false
+
 -- shim vim for kitty and other generators
 vim = vim or {g = {}, o = {}}
 
 local function opt(key, default)
+  key = "onedark_" .. key
   if vim.g[key] == nil then return default end
-  if vim.g[key] == 0 then return false end
+  if vim.g[key] == 0 then
+    vimConfig = true
+    return false
+  end
+  vimConfig = true
   return vim.g[key]
 end
 
-local g = {
-  transparent = "onedark_transparent",
-  commentStyle = "onedark_italic_comments",
-  keywordStyle = "onedark_italic_keywords",
-  functionStyle = "onedark_italic_functions",
-  variableStyle = "onedark_italic_variables",
-  hideInactiveStatusline = "onedark_hide_inactive_statusline",
-  sidebars = "onedark_sidebars",
-  colors = "onedark_colors",
-  dev = "onedark_dev",
-  darkFloat = "onedark_dark_float",
-  darkSidebar = "onedark_dark_sidebar"
-}
-
 config = {
-  transparent = opt(g.transparent, false),
-  commentStyle = opt(g.commentStyle, true) and "italic" or "NONE",
-  keywordStyle = opt(g.keywordStyle, true) and "italic" or "NONE",
-  functionStyle = opt(g.functionStyle, false) and "italic" or "NONE",
-  variableStyle = opt(g.variableStyle, false) and "italic" or "NONE",
-  hideInactiveStatusline = opt(g.hideInactiveStatusline, false),
-  sidebars = opt(g.sidebars, {}),
-  colors = opt(g.colors, {}),
-  dev = opt(g.dev, false),
-  darkFloat = opt(g.darkFloat, true),
-  darkSidebar = opt(g.darkSidebar, true),
+  transparent = opt("transparent", false),
+  commentStyle = opt("italic_comments", true) and "italic" or "NONE",
+  keywordStyle = opt("italic_keywords", true) and "italic" or "NONE",
+  functionStyle = opt("italic_functions", false) and "italic" or "NONE",
+  variableStyle = opt("italic_variables", false) and "italic" or "NONE",
+  hideInactiveStatusline = opt("hide_inactive_statusline", false),
+  sidebars = opt("sidebars", {}),
+  colors = opt("colors", {}),
+  dev = opt("dev", false),
+  darkFloat = opt("dark_float", true),
+  darkSidebar = opt("dark_sidebar", true),
   transform_colors = false
 }
-
-local function isGlobals()
-  for key, gKey in pairs(g) do
-    if vim.g[gKey] ~= nil and vim.g[gKey] ~= config[key] then return true end
-  end
-  return false
-end
 
 local function applyConfiguration(userConfig)
   for key, value in pairs(userConfig) do config[key] = value end
 end
 
-return {config = config, isGlobals = isGlobals, applyConfiguration = applyConfiguration}
+return {config = config, vimConfig = vimConfig, applyConfiguration = applyConfiguration}

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -32,14 +32,15 @@ config = {
   transform_colors = false
 }
 
+---@param userConfig Config
 local function applyConfiguration(userConfig)
   for key, value in pairs(userConfig) do
-    if config[key] ~= nil then
-      config[key] = value
-    else
-      vim.schedule(function()
-        vim.api.nvim_err_writeln("ful1e5/onedark: Unable to set option '" .. key .. "'") -- luacheck: ignore
-      end)
+    if value ~= nil then
+      if config[key] ~= nil then
+        config[key] = value
+      else
+        error("ful1e5/onedark: Option " .. key .. " does not exist") -- luacheck: ignore
+      end
     end
   end
 end

--- a/lua/onedark/extra/alacritty.lua
+++ b/lua/onedark/extra/alacritty.lua
@@ -1,9 +1,10 @@
 local util = require("onedark.util")
+local configModule = require("onedark.config")
 
 local M = {}
 
 function M.alacritty(config)
-  config = config or require("onedark.config")
+  config = config or configModule.config
   config.transform_colors = true
   local colors = require("onedark.colors").setup(config)
 

--- a/lua/onedark/extra/alacritty.lua
+++ b/lua/onedark/extra/alacritty.lua
@@ -46,8 +46,7 @@ colors:
   indexed_colors:
     - { index: 16, color: '${orange}' }
     - { index: 17, color: '${red1}' }
-    
-  ]], alacrittyColors)
+]], alacrittyColors)
 
   return alacritty
 end

--- a/lua/onedark/extra/init.lua
+++ b/lua/onedark/extra/init.lua
@@ -1,6 +1,6 @@
 package.path = "./lua/?/init.lua;./lua/?.lua"
 
-local config = require("onedark.config")
+local configModule = require("onedark.config")
 
 local function write(str, fileName)
   print("[write] extra/" .. fileName)
@@ -12,5 +12,5 @@ end
 local extras = {kitty = "conf", alacritty = "yml"}
 for extra, ext in pairs(extras) do
   local plugin = require("onedark.extra." .. extra)
-  write(plugin[extra](config), extra .. "_onedark_" .. "." .. ext)
+  write(plugin[extra](configModule.config), extra .. "_onedark_" .. "." .. ext)
 end

--- a/lua/onedark/extra/kitty.lua
+++ b/lua/onedark/extra/kitty.lua
@@ -9,46 +9,46 @@ function M.kitty(config)
   local colors = require("onedark.colors").setup(config)
 
   local kitty = util.template([[
-  # onedark colors for Kitty
-  
-  background ${bg}
-  foreground ${fg}
-  selection_background ${bg_visual}
-  selection_foreground ${fg}
-  url_color ${green}
-  cursor ${fg}
-  
-  # Tabs
-  active_tab_background ${blue}
-  active_tab_foreground ${bg}
-  inactive_tab_background ${fg}
-  inactive_tab_foreground ${bg}
-  #tab_bar_background ${black}
-  
-  # normal
-  color0 ${black}
-  color1 ${red}
-  color2 ${green}
-  color3 ${yellow}
-  color4 ${blue}
-  color5 ${purple}
-  color6 ${cyan}
-  color7 ${fg_dark}
-  
-  # bright
-  color8 ${fg_gutter}
-  color9 ${red}
-  color10 ${green}
-  color11 ${yellow}
-  color12 ${blue}
-  color13 ${purple}
-  color14 ${cyan}
-  color15 ${fg}
-  
-  # extended colors
-  color16 ${orange}
-  color17 ${red1}
-  ]], colors)
+# onedark colors for Kitty
+
+background ${bg}
+foreground ${fg}
+selection_background ${bg_visual}
+selection_foreground ${fg}
+url_color ${green}
+cursor ${fg}
+
+# Tabs
+active_tab_background ${blue}
+active_tab_foreground ${bg}
+inactive_tab_background ${fg}
+inactive_tab_foreground ${bg}
+#tab_bar_background ${black}
+
+# normal
+color0 ${black}
+color1 ${red}
+color2 ${green}
+color3 ${yellow}
+color4 ${blue}
+color5 ${purple}
+color6 ${cyan}
+color7 ${fg_dark}
+
+# bright
+color8 ${fg_gutter}
+color9 ${red}
+color10 ${green}
+color11 ${yellow}
+color12 ${blue}
+color13 ${purple}
+color14 ${cyan}
+color15 ${fg}
+
+# extended colors
+color16 ${orange}
+color17 ${red1}
+]], colors)
   return kitty
 end
 

--- a/lua/onedark/extra/kitty.lua
+++ b/lua/onedark/extra/kitty.lua
@@ -1,9 +1,10 @@
 local util = require("onedark.util")
+local configModule = require("onedark.config")
 
 local M = {}
 
 function M.kitty(config)
-  config = config or require("onedark.config")
+  config = config or configModule.config
   config.transform_colors = true
   local colors = require("onedark.colors").setup(config)
 

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -3,16 +3,19 @@ local theme = require("onedark.theme")
 local configModule = require("onedark.config")
 
 local function setup(userConfig)
-  if userConfig then
-    configModule.applyConfiguration(userConfig)
-  elseif configModule.vimConfig then
+  -- Warning, If config set inside 'vim.g'
+  if configModule.vimConfig then
     vim.schedule(function()
       vim.api.nvim_err_writeln(
           [[ful1e5/onedark: onedark will stop supporting vimscript soon, change your config to lua or wrap it around lua << EOF ... EOF]]) -- luacheck: ignore
     end)
   end
+
+  -- Applying user configuration
+  if userConfig then configModule.applyConfiguration(userConfig) end
+
+  -- Load colorscheme
   util.load(theme.setup(configModule.config))
-  vim.cmd [[colorscheme onedark]]
 end
 
 return {setup = setup}

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -5,7 +5,7 @@ local configModule = require("onedark.config")
 local function setup(userConfig)
   if userConfig then
     configModule.applyConfiguration(userConfig)
-  elseif configModule.isGlobals() then
+  elseif configModule.vimConfig then
     vim.schedule(function()
       vim.api.nvim_err_writeln(
           [[ful1e5/onedark: onedark will stop supporting vimscript soon, change your config to lua or wrap it around lua << EOF ... EOF]]) -- luacheck: ignore

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -12,6 +12,7 @@ local function setup(userConfig)
     end)
   end
   util.load(theme.setup(configModule.config))
+  vim.cmd [[colorscheme onedark]]
 end
 
 return {setup = setup}

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -1,10 +1,17 @@
 local util = require("onedark.util")
 local theme = require("onedark.theme")
+local configModule = require("onedark.config")
 
-local M = {}
-
-function M.colorscheme()
-  util.load(theme.setup())
+local function setup(userConfig)
+  if userConfig then
+    configModule.applyConfiguration(userConfig)
+  elseif configModule.isGlobals() then
+    vim.schedule(function()
+      vim.api.nvim_err_writeln(
+          [[ful1e5/onedark: onedark will stop supporting vimscript soon, change your config to lua or wrap it around lua << EOF ... EOF]]) -- luacheck: ignore
+    end)
+  end
+  util.load(theme.setup(configModule.config))
 end
 
-return M
+return {setup = setup}

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -326,7 +326,7 @@ function M.setup(config)
     theme.base.StatusLineNC = inactive
 
     -- LuaLine
-    for _, section in ipairs({"a", "b", "c"}) do
+    for _, section in pairs({"a", "b", "c"}) do
       theme.plugins["lualine_" .. section .. "_inactive"] = inactive
     end
   end

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -15,7 +15,7 @@ function M.setup(config)
   theme.colors = colors.setup(config)
   local c = theme.colors
 
-  theme.base = {
+  theme.base = { -- luacheck: ignore
     Comment = {fg = c.fg_gutter, style = config.commentStyle}, -- any comment
     ColorColumn = {bg = c.bg_visual}, -- used for the columns set with 'colorcolumn'
     Conceal = {fg = c.fg_gutter}, -- placeholder characters substituted for concealed text (see 'conceallevel')

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -1,12 +1,13 @@
 local util = require("onedark.util")
 local colors = require("onedark.colors")
+local configModule = require("onedark.config")
 
 local M = {}
 
 ---@param config Config
 ---@return Theme
 function M.setup(config)
-  config = config or require("onedark.config")
+  config = config or configModule.config
 
   ---@class Theme
   local theme = {}


### PR DESCRIPTION
### Added

- **Warning** on `vim.g` configuration
- Configure plugin in lua using `require('onedark').setup({})`  (monsonjeremy/onedark.nvim#5 fixed)
- Minimal config example added inside [README.md#minimal](./README.md#minimal)
- Linting Github Action init
- Format .lua code with [lua-format](https://github.com/Koihik/LuaFormatter)
- **kitty tab** colors are changed
- Init: `Makefile, .lua-format, .luacheckrc`

### Changed

- Function removed `require('onedark').colorscheme()`
- Colorscheme **autoload removed** from `colors/onedark.vim`
- **VertSplit** & **Inactive StatusLine** `fg` color changed to `bg_visual`
- StatusLine bug note inside [README.md#usage](./README.md#-usage)
- Configuration docs updated inside [README.md#configuration](./README.md#-configuration)
