### PR TITLE
🔧 (fix #6) Parse lua table inside `colors` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration docs updated inside [README.md#configuration](./README.md#-configuration)
 - Fix `VertSplit` & `StatusLine` crossover on `hideInactiveStatusline` [check hoob3rt/lualine.nvim#274]
 - Change `NvimTreeEndOfBuffer` color on `darkSidebar=false`
+- Parse lua table inside `colors` config **[fix #6]**
 
 ## [v0.0.1] - 14 June 2021
 

--- a/lua/onedark/util.lua
+++ b/lua/onedark/util.lua
@@ -221,19 +221,25 @@ function util.load(theme)
   end, 0)
 end
 
----@param config Config
 ---@param colors ColorScheme
+---@param config Config
 function util.color_overrides(colors, config)
   if type(config.colors) == "table" then
     for key, value in pairs(config.colors) do
       if not colors[key] then error("Color " .. key .. " does not exist") end
-      if string.sub(value, 1, 1) == "#" then
-        -- hex override
-        colors[key] = value
+
+      -- Patch: https://github.com/ful1e5/onedark.nvim/issues/6
+      if type(colors[key]) == "table" then
+        util.color_overrides(colors[key], {colors = value})
       else
-        -- another group
-        if not colors[value] then error("Color " .. value .. " does not exist") end
-        colors[key] = colors[value]
+        if string.sub(value, 1, 1) == "#" then
+          -- hex override
+          colors[key] = value
+        else
+          -- another group
+          if not colors[value] then error("Color " .. value .. " does not exist") end
+          colors[key] = colors[value]
+        end
       end
     end
   end


### PR DESCRIPTION
### Changes
- Apply recursion inside `util.color_overrides` for parsing lua table inside **colors** config.

