### PR TITLE
glyph-palette.vim plugin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **kitty tab** colors are changed
 - Init: `Makefile, .lua-format, .luacheckrc`
 - Add "NONE" color compatibility for colors override
-- `barbar.nvim` plugin support ( related to monsonjeremy/onedark.nvim#8 )
+- `barbar.nvim` plugin support. related to monsonjeremy/onedark.nvim#8
+- `glyph-palette.vim` plugin support
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [Lightline](https://github.com/itchyny/lightline.vim)
 - [Neogit](https://github.com/TimUntersberger/neogit)
 - [Barbar](https://github.com/romgrk/barbar.nvim)
+- [glyph-palette.vim](https://github.com/lambdalisue/glyph-palette.vim)
 
 ## ⚡️ Requirements
 

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -303,6 +303,15 @@ function M.setup(config)
     DashboardCenter = {fg = c.blue},
     DashboardFooter = {fg = c.yellow, style = "italic"},
 
+    -- glyph palette
+    GlyphPalette1 = {fg = c.red1},
+    GlyphPalette2 = {fg = c.green},
+    GlyphPalette3 = {fg = c.yellow},
+    GlyphPalette4 = {fg = c.blue},
+    GlyphPalette6 = {fg = c.green},
+    GlyphPalette7 = {fg = c.fg},
+    GlyphPalette9 = {fg = c.red},
+
     -- WhichKey
     WhichKey = {fg = c.yellow},
     WhichKeyGroup = {fg = c.blue},
@@ -349,6 +358,7 @@ function M.setup(config)
     -- ALE
     ALEWarningSign = {fg = c.yellow},
     ALEErrorSign = {fg = c.red}
+
   }
 
   theme.defer = {}


### PR DESCRIPTION
### Changes
- added `glyph-palette.vim` highlights inside `lua/onedark/theme.lua`
- plugins list updated inside `README.md`