### PR TITLE
Kitty border color changed to `bg_visual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add "NONE" color compatibility for colors override
 - `barbar.nvim` plugin support. related to monsonjeremy/onedark.nvim#8
 - `glyph-palette.vim` plugin support
+- kitty border color added
+- `./colors/onedark.vim` code in lua
 
 ### Changed
 

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -1,7 +1,11 @@
-" clear cache so this reloads changes.
-" useful for development
-lua package.loaded['onedark'] = nil
-lua package.loaded['onedark.theme'] = nil
-lua package.loaded['onedark.colors'] = nil
-lua package.loaded['onedark.util'] = nil
-lua package.loaded['onedark.config'] = nil
+lua << EOF
+
+-- clear cache so this reloads changes.
+-- useful for development
+package.loaded['onedark'] = nil
+package.loaded['onedark.util'] = nil
+package.loaded['onedark.colors'] = nil
+package.loaded['onedark.theme'] = nil
+package.loaded['onedark.config'] = nil
+
+EOF

--- a/extras/kitty_onedark_.conf
+++ b/extras/kitty_onedark_.conf
@@ -12,7 +12,10 @@ active_tab_background #61afef
 active_tab_foreground #282c34
 inactive_tab_background #abb2bf
 inactive_tab_foreground #282c34
-#tab_bar_background #20232A
+
+# Windows Border
+active_border_color #393f4a
+inactive_border_color #393f4a
 
 # normal
 color0 #20232A

--- a/lua/onedark/extra/kitty.lua
+++ b/lua/onedark/extra/kitty.lua
@@ -23,7 +23,10 @@ active_tab_background ${blue}
 active_tab_foreground ${bg}
 inactive_tab_background ${fg}
 inactive_tab_foreground ${bg}
-#tab_bar_background ${black}
+
+# Windows Border
+active_border_color ${bg_visual}
+inactive_border_color ${bg_visual}
 
 # normal
 color0 ${black}


### PR DESCRIPTION
### Changes
- Add `lua` code inside `colors/onedark.vim`
- Kitty border color changed to `bg_visual`

### Preview
#### before
![Screenshot_20210815_161206](https://user-images.githubusercontent.com/24286590/129475810-06779877-077b-462e-a67b-9d234a077c4d.png)

#### patch
![Screenshot_20210815_161056](https://user-images.githubusercontent.com/24286590/129475811-7c4738fa-d230-4144-8cc9-5992a7669d1d.png)
