### PR TITLE
feat: `msgAreaStyle` config added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - kitty border color added
 - `./colors/onedark.vim` code in lua
 - [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) plugin support
+- `msgAreaStyle` config added
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ vim.g.lightline = {colorscheme = "onedark"}
 | keywordStyle           | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                         |
 | functionStyle          | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
 | variableStyle          | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
+| msgAreaStyle           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                             |
 | transparent            | `false`  | Enable this to disable setting the background color                                                                                                             |
 | hideInactiveStatusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
 | sidebars               | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -26,6 +26,7 @@ config = {
   keywordStyle = opt("italic_keywords", true) and "italic" or "NONE",
   functionStyle = opt("italic_functions", false) and "italic" or "NONE",
   variableStyle = opt("italic_variables", false) and "italic" or "NONE",
+  msgAreaStyle = opt("italic_msg_area", false) and "italic" or "NONE",
   hideInactiveStatusline = opt("hide_inactive_statusline", false),
   sidebars = opt("sidebars", {}),
   colors = opt("colors", {}),

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -43,7 +43,7 @@ function M.setup(config)
     CursorLineNr = {fg = c.dark5}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {fg = c.orange, style = "bold"}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg_dark, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")
-    MsgArea = {fg = c.fg_dark}, -- Area for messages and cmdline
+    MsgArea = {fg = c.fg_dark, style = config.msgAreaStyle}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     MoreMsg = {fg = c.blue}, -- |more-prompt|
     NonText = {fg = c.bg}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.


### PR DESCRIPTION
### Changes
-  `msgAreaStyle` variable added inside `config.lua`
- updated logs inside `CHANGELOG.md`
- docs updated iniside `README.md`

### Default Config
```lua
require("onedark").setup({
  msgAreaStyle = "NONE"
  -- other onedark.nvim config
})

```
#### Default
![Screenshot_20210824_145035](https://user-images.githubusercontent.com/24286590/130592297-9f3991b2-75e4-4ab8-ab73-ac6e6dfc0589.png)

#### Bold
![Screenshot_20210824_144932](https://user-images.githubusercontent.com/24286590/130592285-e4de6c40-4662-4266-9c9b-8ad645c71daf.png)

#### Italic
![Screenshot_20210824_145004](https://user-images.githubusercontent.com/24286590/130592294-37d477d5-d6d1-4efb-91aa-251f84f943a6.png)
