### PR TITLE
 feat:`TSVariable` & `TSOperator` colors added inside `colors.lua`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) plugin support
 - `msgAreaStyle` config added
 - `kitty` target added inside `Makefile` for reloading kitty theme
+- `TSVariable` & `TSOperator` colors added inside `colors.lua`
 
 ### Changed
 

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -34,6 +34,13 @@ function M.setup(config)
     red1 = "#f65866",
     git = {change = "#e0af68", add = "#109868", delete = "#9A353D", conflict = "#bb7a61"},
     gitSigns = {change = "#e0af68", add = "#109868", delete = "#9A353D"},
+
+    syntax = {
+      variable = "#e06c75",
+      operator = "#56b6c2"
+      --
+
+    },
     devIcons = {
       c = "#519aba",
       clojure = "#8dc149",

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -208,7 +208,7 @@ function M.setup(config)
     TSNamespace = {fg = c.red}, -- For identifiers referring to modules and namespaces.
     -- TSNone              = { };    -- TODO: docs
     -- TSNumber            = { };    -- For all numbers
-    TSOperator = {fg = c.fg}, -- For any operator: `+`, but also `->` and `*` in C.
+    TSOperator = {fg = c.syntax.operator}, -- For any operator: `+`, but also `->` and `*` in C.
     TSParameter = {fg = c.red}, -- For parameters of a function.
     -- TSParameterReference= { };    -- For references to parameters of a function.
     TSProperty = {fg = c.red}, -- Same as `TSField`.
@@ -222,7 +222,7 @@ function M.setup(config)
     -- TSSymbol            = { };    -- For identifiers referring to symbols or atoms.
     -- TSType              = { };    -- For types.
     -- TSTypeBuiltin       = { };    -- For builtin types.
-    TSVariable = {style = config.variableStyle}, -- Any variable name that does not have another highlight.
+    TSVariable = {fg = c.syntax.variable, style = config.variableStyle}, -- Any variable name that does not have another highlight.
     TSVariableBuiltin = {fg = c.red}, -- Variable names that are defined by the languages, like `this` or `self`.
     TSTag = {fg = c.red}, -- Tags like html tag names.
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`


### PR DESCRIPTION
### Changes
- syntax colors added inside `colors.lua`
- `TSVariable` & `TSOperator` colors improved according to `c` langauge

### Preview
#### Before
![c before](https://user-images.githubusercontent.com/24286590/131483133-ece61bcb-a9f7-4159-8cb8-c14b37e14494.png)

#### Patch
![c after](https://user-images.githubusercontent.com/24286590/131483143-844536a2-2bcd-48af-9ec6-067108b89a83.png)
