### PR TITLE
fix: javascript function_name highlight

### DIFF
--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -40,9 +40,8 @@ function M.setup(config)
       variable = "#e06c75",
       operator = "#56b6c2",
       property = "#56b6c2",
-      variable_builtin = "#e5c07b"
-
-      --
+      variable_builtin = "#e5c07b",
+      js = {func = "#e5c07b"}
     },
 
     devIcons = {

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -237,6 +237,7 @@ function M.setup(config)
 
     -- Lua
     -- luaTSProperty = { fg = c.red }, -- Same as `TSField`.
+    javascriptTSFunction = {fg = c.syntax.js.func}, -- For function (calls and definitions).
 
     -- LspTrouble
     LspTroubleText = {fg = c.fg_dark},


### PR DESCRIPTION
### Fix Preview
#### Before
![javascriptTSFunction before](https://user-images.githubusercontent.com/24286590/131835597-164a113f-6000-45c9-95cb-ff2cd396b15d.png)

#### Patch
![javascriptTSFunction after](https://user-images.githubusercontent.com/24286590/131835604-f6b01914-d573-4b57-ae99-758e609bd2bb.png)
