### PR TITLE
feat: Assign `dark5` color to `LineNr` inside `transparent` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - docs updated
+- Assign `dark5` color to `LineNr` inside `transparent` mode
 
 ### Changed
 

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -39,7 +39,7 @@ function M.setup(config)
     SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed
     SignColumnSB = {bg = c.bg_sidebar, fg = c.fg_gutter}, -- column where |signs| are displayed
     Substitute = {bg = c.red, fg = c.black}, -- |:substitute| replacement text highlighting
-    LineNr = {fg = c.fg_gutter}, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
+    LineNr = {fg = config.transparent and c.dark5 or c.fg_gutter}, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
     CursorLineNr = {fg = c.dark5}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {fg = c.orange, style = "bold"}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg_dark, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")


### PR DESCRIPTION
### Change Preview:

#### Before

![linenr_before](https://user-images.githubusercontent.com/24286590/135059020-b9da5663-6b3c-4d60-8c1d-13d50d180839.png)

#### Patch
![linenr_patch](https://user-images.githubusercontent.com/24286590/135059049-4b0cd464-8600-453a-b705-9ec65f370366.png)

