### PR TITLE
feat: highlight_linenumber config for setting dark color to number-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: contributing guidelines added
 - docs: code of conduct added
 - feat: `highlight_linenumber` config for setting dark color to number line
+- feat: support `highlight_linenumber` with gitsigns
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Assign `dark5` color to `LineNr` inside `transparent` mode
 - docs: contributing guidelines added
 - docs: code of conduct added
+- feat: `highlight_linenumber` config for setting dark color to number line
 
 ### Changed
 
 - projekt0n/github-nvim-theme#73 fixed
 - refactor: lualine colors added inside `colors.lua`
 - breaking change: consistent variable naming in `onedark` config
+- undefined color `syntax.comment` fixed
 
 ## [v0.0.2]- 19 Sep 2021
 

--- a/README.md
+++ b/README.md
@@ -98,20 +98,20 @@ require('lualine').setup {
 
 ## ⚙️ Configuration
 
-| Option                   | Default  | Description                                                                                                                                                     |
-| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| comment_style            | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                                         |
-| keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                         |
-| function_style           | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
-| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
-| msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                             |
-| transparent              | `false`  | Enable this to disable setting the background color                                                                                                             |
-| hide_inactive_statusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
-| highlight_linenumber     | `false`  | Enabling this option, will enable dark color to `LineNr` and `CursorLineNr` highlights.                                                                         |
-| sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
-| dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
-| dark_float               | `true`   | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
-| colors                   | `{}`     | You can override specific color groups to use other groups or a hex color                                                                                       |
+| Option                   | Default  | Description                                                                                                                                                                       |
+| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| comment_style            | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                                                           |
+| keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                                           |
+| function_style           | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                                          |
+| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                                          |
+| msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                                               |
+| transparent              | `false`  | Enable this to disable setting the background color                                                                                                                               |
+| hide_inactive_statusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**.                   |
+| highlight_linenumber     | `false`  | Enabling this option, will enable dark color to `LineNr`, `SignColumn` and `CursorLineNr` highlights.(also support [gitsigns](https://github.com/lewis6991/gitsigns.nvim) plugin) |
+| sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                                        |
+| dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                                      |
+| dark_float               | `true`   | Float windows like the lsp diagnostics windows get a darker background.                                                                                                           |
+| colors                   | `{}`     | You can override specific color groups to use other groups or a hex color                                                                                                         |
 
 ```lua
 -- Example config in Lua
@@ -223,6 +223,20 @@ require("onedark").setup({
 
 <p align="center">
   <img src="https://imgur.com/uloZd1y.png" alt="Minimal" />
+</p>
+
+### Highlight Line-Number
+
+```lua
+require("onedark").setup({
+  dark_sidebar = false,
+  highlight_linenumber = true
+  -- ... your onedark config
+})
+```
+
+<p align="center">
+  <img src="https://imgur.com/StVkP8t.png" alt="Highlight Line-Number" />
 </p>
 
 ### Telescope

--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ require('lualine').setup {
 | ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | comment_style            | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                                         |
 | keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                         |
-| function_style            | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
-| variable_style            | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
+| function_style           | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
+| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
 | msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                             |
 | transparent              | `false`  | Enable this to disable setting the background color                                                                                                             |
 | hide_inactive_statusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
+| highlight_linenumber     | `false`  | Enabling this option, will enable dark color to `LineNr` and `CursorLineNr` highlights.                                                                         |
 | sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
 | dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
 | dark_float               | `true`   | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -42,6 +42,7 @@ function M.setup(config)
       operator = "#56b6c2",
       property = "#56b6c2",
       variable_builtin = "#e5c07b",
+      comment = "#5c6370",
       js = {
         func = "#e5c07b",
         variable = "#e5c07b",

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -150,6 +150,11 @@ function M.setup(config)
   colors.bg_sidebar = config.transparent and colors.none or colors.bg_sidebar
   colors.bg_float = config.dark_float and colors.bg2 or colors.bg
 
+  -- LineNumber is configurable
+  colors.bg_linenumber = config.highlight_linenumber and colors.bg2 or colors.bg
+  colors.fg_linenumber = colors.fg_gutter
+  colors.fg_cursor_linenumber = colors.dark5
+
   colors.bg_search = colors.bg_yellow
   colors.fg_search = colors.bg2
   colors.fg_sidebar = colors.fg_dark

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -29,6 +29,7 @@ config = {
   variable_style = opt("italic_variables", false) and "italic" or "NONE",
   msg_area_style = opt("italic_msg_area", false) and "italic" or "NONE",
   hide_inactive_statusline = opt("hide_inactive_statusline", false),
+  highlight_linenumber = opt("highlight_linenumber", false),
   sidebars = opt("sidebars", {}),
   colors = opt("colors", {}),
   dev = opt("dev", false),

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -39,8 +39,11 @@ function M.setup(config)
     SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed
     SignColumnSB = {bg = c.bg_sidebar, fg = c.fg_gutter}, -- column where |signs| are displayed
     Substitute = {bg = c.red, fg = c.black}, -- |:substitute| replacement text highlighting
-    LineNr = {fg = config.transparent and c.dark5 or c.fg_gutter}, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
-    CursorLineNr = {fg = c.dark5}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
+    LineNr = {
+      fg = config.transparent and c.fg_cursor_linenumber or c.fg_linenumber,
+      bg = c.bg_linenumber
+    }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
+    CursorLineNr = {fg = c.dark5, bg = c.bg_linenumber}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {fg = c.orange, style = "bold"}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg_dark, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")
     MsgArea = {fg = c.fg_dark, style = config.msg_area_style}, -- Area for messages and cmdline
@@ -125,7 +128,7 @@ function M.setup(config)
 
     Error = {fg = c.error}, -- (preferred) any erroneous construct
     Todo = {bg = c.yellow, fg = c.bg}, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
-    qfLineNr = {fg = c.dark5},
+    qfLineNr = {link = "CursorLineNr"},
     qfFileName = {fg = c.blue},
     htmlTag = {fg = c.purple, style = "bold"},
     -- mkdHeading = { fg = c.orange, style = "bold" },

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -16,7 +16,7 @@ function M.setup(config)
   local c = theme.colors
 
   theme.base = { -- luacheck: ignore
-    Comment = {fg = c.fg_gutter, style = config.comment_style}, -- any comment
+    Comment = {fg = c.syntax.comment, style = config.comment_style}, -- any comment
     ColorColumn = {bg = c.bg_visual}, -- used for the columns set with 'colorcolumn'
     Conceal = {fg = c.fg_gutter}, -- placeholder characters substituted for concealed text (see 'conceallevel')
     Cursor = {fg = c.cursor, bg = c.fg}, -- character under the cursor
@@ -65,7 +65,7 @@ function M.setup(config)
     SpellCap = {sp = c.warning, style = "undercurl"}, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
     SpellLocal = {sp = c.info, style = "undercurl"}, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
     SpellRare = {sp = c.hint, style = "undercurl"}, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
-    StatusLine = {fg = c.syntax.comment, bg = c.bg_statusline}, -- status line of current window
+    StatusLine = {fg = c.fg, bg = c.bg_statusline}, -- status line of current window
     StatusLineNC = {fg = c.fg_gutter, bg = c.bg}, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
     TabLine = {bg = c.bg_statusline, fg = c.fg_gutter}, -- tab pages line, not active tab page label
     TabLineFill = {bg = c.black}, -- tab pages line, where there are no labels

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -36,7 +36,7 @@ function M.setup(config)
     VertSplit = {fg = c.bg_visual}, -- the column separating vertically split windows
     Folded = {fg = c.blue, bg = c.fg_gutter}, -- line used for closed folds
     FoldColumn = {bg = c.bg, fg = c.fg_gutter}, -- 'foldcolumn'
-    SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed
+    SignColumn = {bg = config.transparent and c.none or c.bg_linenumber, fg = c.fg_gutter}, -- column where |signs| are displayed
     SignColumnSB = {bg = c.bg_sidebar, fg = c.fg_gutter}, -- column where |signs| are displayed
     Substitute = {bg = c.red, fg = c.black}, -- |:substitute| replacement text highlighting
     LineNr = {
@@ -169,6 +169,10 @@ function M.setup(config)
     DiagnosticWarn = {link = "LspDiagnosticsDefaultWarning"}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
     DiagnosticInfo = {link = "LspDiagnosticsDefaultInformation"}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
     DiagnosticHint = {link = "LspDiagnosticsDefaultHint"}, -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    DiagnosticsVirtualTextError = {link = "LspDiagnosticsVirtualTextError"}, -- Used for "Error" diagnostic virtual text
+    DiagnosticsVirtualTextWarning = {link = "LspDiagnosticsVirtualTextWarning"}, -- Used for "Warning" diagnostic virtual text
+    DiagnosticsVirtualTextInformation = {link = "LspDiagnosticsVirtualTextInformation"}, -- Used for "Information" diagnostic virtual text
+    DiagnosticsVirtualTextHint = {link = "LspDiagnosticsVirtualTextHint"}, -- Used for "Hint" diagnostic virtual text
     DiagnosticUnderlineError = {link = "LspDiagnosticsUnderlineError"}, -- Used to underline "Error" diagnostics
     DiagnosticUnderlineWarn = {link = "LspDiagnosticsUnderlineWarning"}, -- Used to underline "Warning" diagnostics
     DiagnosticUnderlineInfo = {link = "LspDiagnosticsUnderlineInformation"}, -- Used to underline "Information" diagnostics
@@ -342,9 +346,9 @@ function M.setup(config)
     GitGutterDelete = {fg = c.gitSigns.delete}, -- diff mode: Deleted line |diff.txt|
 
     -- GitSigns
-    GitSignsAdd = {fg = c.gitSigns.add}, -- diff mode: Added line |diff.txt|
-    GitSignsChange = {fg = c.gitSigns.change}, -- diff mode: Changed line |diff.txt|
-    GitSignsDelete = {fg = c.gitSigns.delete}, -- diff mode: Deleted line |diff.txt|
+    GitSignsAdd = {fg = c.gitSigns.add, bg = c.bg_linenumber}, -- diff mode: Added line |diff.txt|
+    GitSignsChange = {fg = c.gitSigns.change, bg = c.bg_linenumber}, -- diff mode: Changed line |diff.txt|
+    GitSignsDelete = {fg = c.gitSigns.delete, bg = c.bg_linenumber}, -- diff mode: Deleted line |diff.txt|
 
     -- Telescope
     TelescopeBorder = {fg = c.border},

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -357,8 +357,8 @@ function M.setup(config)
 
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},
-    NvimTreeEndOfBuffer = config.dark_sidebar and {fg = c.bg2} or {fg = c.bg},
-    NvimTreeRootFolder = {fg = c.fg_light, style = "bold"},
+    NvimTreeEndOfBuffer = {fg = c.bg_sidebar},
+    NvimTreeRootFolder = {fg = c.fg_light, style = "bold", bg = c.bg_sidebar},
     NvimTreeGitDirty = {fg = c.yellow2},
     NvimTreeGitNew = {fg = c.git.add},
     NvimTreeGitDeleted = {fg = c.git.delete},


### PR DESCRIPTION
### fixes:
- nvimtree path name highlight
- undefined color `syntax.comment` 

### feature:
 - dark color for line number
 - enhance number readability in `transparent` mode
 - support with [gitsigns](https://github.com/lewis6991/gitsigns.nvim)

### feature preview:
![Line Highlight](https://user-images.githubusercontent.com/24286590/135967263-70707d22-278c-4f16-9f5c-a1b542e5bf5a.png)

