### PR TITLE
refactor: `config` module for full `vim.g` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: removed emoji from README.md
 - cleanup: removed vim config deprecated message
 - breaking change: use snake_case inside config and alacritty module
+- breaking change: changed config variables name inside `vim.g` variables
 
 ## [v0.0.2]- 19 Sep 2021
 

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -29,11 +29,11 @@ end
 
 config = {
   transparent = opt("transparent", false),
-  comment_style = opt("italic_comments", true) and "italic" or "NONE",
-  keyword_style = opt("italic_keywords", true) and "italic" or "NONE",
-  function_style = opt("italic_functions", false) and "italic" or "NONE",
-  variable_style = opt("italic_variables", false) and "italic" or "NONE",
-  msg_area_style = opt("italic_msg_area", false) and "italic" or "NONE",
+  comment_style = opt("comment_style", "italic"),
+  keyword_style = opt("keyword_style", "italic"),
+  function_style = opt("function_style", "italic"),
+  variable_style = opt("variable_style", "NONE"),
+  msg_area_style = opt("msg_area_style", "NONE"),
   hide_inactive_statusline = opt("hide_inactive_statusline", false),
   highlight_linenumber = opt("highlight_linenumber", false),
   sidebars = opt("sidebars", {}),


### PR DESCRIPTION
## Breaking Changes
- changed config variables name inside `vim.g` variables (according to [README.md#configuration](https://github.com/ful1e5/onedark.nvim#configuration))
## Feature
- store `user_config` value to `vim.g` variables
