### PR TITLE
fix: missing DiffText highlighting

### DIFF
--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -108,7 +108,8 @@ function M.setup(config)
   colors.diff = {
     add = util.darken(colors.git.add, 0.15),
     delete = util.darken(colors.git.delete, 0.15),
-    change = util.darken(colors.git.change, 0.15)
+    change = util.darken(colors.git.change, 0.15),
+    text = util.darken(colors.git.change, 0.25)
   }
 
   colors.git_signs = {

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -28,7 +28,7 @@ function M.setup(config)
     DiffAdd = {bg = c.diff.add}, -- diff mode: Added line |diff.txt|
     DiffChange = {bg = c.diff.change}, -- diff mode: Changed line |diff.txt|
     DiffDelete = {bg = c.diff.delete}, -- diff mode: Deleted line |diff.txt|
-    DiffText = {fg = c.fg_gutter}, -- diff mode: Changed text within a changed line |diff.txt|
+    DiffText = {bg = c.diff.text}, -- diff mode: Changed text within a changed line |diff.txt|
     EndOfBuffer = {fg = c.bg}, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal


### PR DESCRIPTION
I noticed that the `DiffText` highlighting makes the text and its background grey. I've changed so that `DiffText` has the same color as the surrounding `DiffChange` but with a slightly brighter tint to make it stand out.
