### PR TITLE
Allow LineNr and CursorLineNr to be transparent

### DIFF
--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -41,9 +41,12 @@ function M.setup(config)
     Substitute = {bg = c.red, fg = c.black}, -- |:substitute| replacement text highlighting
     LineNr = {
       fg = config.transparent and c.fg_cursor_linenumber or c.fg_linenumber,
-      bg = c.bg_linenumber
+      bg = config.transparent and c.none or c.bg_linenumber
     }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
-    CursorLineNr = {fg = c.dark5, bg = c.bg_linenumber}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
+    CursorLineNr = {
+      fg = c.dark5,
+      bg = config.transparent and c.none or c.bg_linenumber
+    }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {fg = c.orange, style = "bold"}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg_dark, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")
     MsgArea = {fg = c.fg_dark, style = config.msg_area_style}, -- Area for messages and cmdline


### PR DESCRIPTION
Before:
![Screen Shot 2021-12-09 at 12 41 21](https://user-images.githubusercontent.com/23235841/145390190-8db32b17-7958-49d5-85be-4cf7db6050c9.png)

After (with `transparent=true`):

![Screen Shot 2021-12-09 at 12 42 09](https://user-images.githubusercontent.com/23235841/145390304-fbe3ce1c-abb7-4f85-b7bd-eb46c57a0c6f.png)


Full config used in screenshots:

```lua
require("onedark").setup({
    transparent = true,
    transparent_sidebar = false,
    comment_style = "NONE",
    keyword_style = "NONE",
    function_style = "NONE",
    variable_style = "NONE",
    colors = {
        fg = '#ffffff',
        fg_light = '#ffffff',
        fg_dark = '#ffffff'
    }
})
```
