### PR TITLE
Add highlight to telescope.nvim's prompt counter

### DIFF
--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -357,6 +357,7 @@ function M.setup(config)
     TelescopeBorder = {fg = c.border},
     TelescopeMatching = {fg = c.fg_light, style = "bold"},
     TelescopePromptPrefix = {fg = c.fg, style = "bold"},
+    TelescopePromptCounter = {fg = c.blue},
 
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},


### PR DESCRIPTION
I noticed that telescope's prompt counter doesn't show and it's because it's linked to `NonText` by default which has the same color as the background and therefore doesn't show.