### PR TITLE
Some minor Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `hide_inactive_statusline` option deprecated from `lualine` plugin
+- `javascriptTSTagAttribute` highlight removed
+- `TSTagAttribute` highlight added
 
 ## [v0.0.3]- 11 Dec 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hide_inactive_statusline` option deprecated from `lualine` plugin
 - `javascriptTSTagAttribute` highlight removed
 - `TSTagAttribute` highlight added
+- yellow changed to the same version as onedark palette. monsonjeremy/onedark.nvim#19
 
 ## [v0.0.3]- 11 Dec 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `javascriptTSTagAttribute` highlight removed
 - `TSTagAttribute` highlight added
 - yellow changed to the same version as onedark palette. monsonjeremy/onedark.nvim#19
+- Boolean set to orange as in VSC onedark theme. monsonjeremy/onedark.nvim#19
 
 ## [v0.0.3]- 11 Dec 2021
 

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -42,12 +42,8 @@ function M.setup(config)
       property = "#56b6c2",
       variable_builtin = "#e5c07b",
       comment = "#5c6370",
-      js = {
-        func = "#e5c07b",
-        variable = "#e5c07b",
-        property = "#61afef",
-        tag_attribute = "#e59b4e"
-      },
+      tag_attribute = "#e59b4e",
+      js = {func = "#e5c07b", variable = "#e5c07b", property = "#61afef"},
       json = {label = "#e06c75"},
       less = {include = "#c678dd", class = "#d19a66"},
       make = {ident = "#e59b4e"},

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -26,7 +26,7 @@ function M.setup(config)
     cyan = "#56b6c2",
     purple = "#c678dd",
     orange = "#d19a66",
-    yellow = "#e0af68",
+    yellow = "#e5c07b",
     yellow2 = "#e2c08d",
     bg_yellow = "#ebd09c",
     green = "#98c379",

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -89,7 +89,7 @@ function M.setup(config)
     String = {fg = c.green}, --   a string constant: "this is a string"
     Character = {fg = c.green}, --  a character constant: 'c', '\n'
     -- Number        = { }, --   a number constant: 234, 0xff
-    -- Boolean       = { }, --  a boolean constant: TRUE, false
+    Boolean = {fg = c.orange}, --  a boolean constant: TRUE, false
     -- Float         = { }, --    a floating point constant: 2.3e10
 
     Identifier = {fg = c.red, style = config.variable_style}, -- (preferred) any variable name

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -242,6 +242,7 @@ function M.setup(config)
     TSVariable = {fg = c.syntax.variable, style = config.variable_style}, -- Any variable name that does not have another highlight.
     TSVariableBuiltin = {fg = c.syntax.variable_builtin}, -- Variable names that are defined by the languages, like `this` or `self`.
     TSTag = {fg = c.red}, -- Tags like html tag names.
+    TSTagAttribute = {fg = c.syntax.tag_attribute},
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`
     -- TSText              = { };    -- For strings considered text in a markup language.
     TSTextReference = {fg = c.red}, -- FIXME
@@ -258,7 +259,6 @@ function M.setup(config)
     javascriptTSFunction = {fg = c.syntax.js.func}, -- For function (calls and definitions).
     javascriptTSVariable = {fg = c.syntax.js.variable},
     javascriptTSProperty = {fg = c.syntax.js.property},
-    javascriptTSTagAttribute = {fg = c.syntax.js.tag_attribute},
 
     -- css
     cssStringQQ = {fg = c.syntax.string, style = "underline"},


### PR DESCRIPTION
Original Work by @RaulCote. Check the upstream PR monsonjeremy/onedark.nvim#19.
### Refactor: 
- rdefine TSTagAttribute highlight in TreeSitter
### Enhancements:
- yellow changed to the same version as the onedark palette.
- Boolean set to orange as in VSC onedark theme. 
