### PR TITLE
Treesitter support for experimental Markdown parser

### DIFF
--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -271,6 +271,15 @@ function M.setup(config)
     -- make
     makeIdent = {fg = c.syntax.make.ident},
 
+    -- markdown
+    TSURI = {fg = c.blue, style = "underline"},
+    TSLiteral = { fg = c.red },
+    TSTextReference = { fg = c.blue },
+    TSTitle = {fg = c.red, style = "bold"},
+    TSEmphasis = { style = "italic" },
+    TSStrong = { style = "bold" },
+    TSStringEscape = { fg = c.yellow },
+
     -- php
     phpTSPunctBracket = {fg = c.syntax.php.punct_bracket},
     phpTSKeyword = {fg = c.syntax.php.keyword},

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -245,7 +245,6 @@ function M.setup(config)
     TSTagAttribute = {fg = c.syntax.tag_attribute},
     -- TSTagDelimiter      = { };    -- Tag delimiter like `<` `>` `/`
     -- TSText              = { };    -- For strings considered text in a markup language.
-    TSTextReference = {fg = c.red}, -- FIXME
     -- TSEmphasis          = { };    -- For text to be represented with emphasis.
     -- TSUnderline         = { };    -- For text to be represented with an underline.
     -- TSStrike            = { };    -- For strikethrough text.
@@ -278,7 +277,6 @@ function M.setup(config)
     TSTitle = {fg = c.red, style = "bold"},
     TSEmphasis = { style = "italic" },
     TSStrong = { style = "bold" },
-    TSStringEscape = { fg = c.yellow },
 
     -- php
     phpTSPunctBracket = {fg = c.syntax.php.punct_bracket},


### PR DESCRIPTION
Just added Treesitter support for the new [experimental Markdown parser](https://github.com/MDeiml/tree-sitter-markdown) that was accepted on nvim-treesitter