### PR TITLE
feat: config option added `hide_end_of_buffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - lualine `terminal` highlight added
 - plugin support [coc.nvim](https://github.com/neoclide/coc.nvim)
 - define global in project `luarc` config file.
+- config option added `hide_end_of_buffer`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -109,20 +109,21 @@ require('lualine').setup {
 
 | Option                   | Default  | Description                                                                                                                                                                       |
 | ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| colors                   | `{}`     | You can override specific color groups to use other groups or a hex color                                                                                                         |
 | comment_style            | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                                                           |
-| keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                                           |
+| dark_float               | `true`   | Float windows like the lsp diagnostics windows get a darker background.                                                                                                           |
+| dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                                      |
 | function_style           | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                                          |
-| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                                          |
-| msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                                               |
-| transparent              | `false`  | Enable this to disable setting the background color                                                                                                                               |
+| hide_end_of_buffer       | `true`   | Enabling this option, will hide filler lines (~) after the end of the buffer                                                                                                      |
 | hide_inactive_statusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine**.                                   |
 | highlight_linenumber     | `false`  | Enabling this option, will enable dark color to `LineNr`, `SignColumn` and `CursorLineNr` highlights.(also support [gitsigns](https://github.com/lewis6991/gitsigns.nvim) plugin) |
+| keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                                           |
 | lualine_bold             | `false`  | When `true`, section headers in the lualine theme will be bold                                                                                                                    |
+| msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                                               |
 | sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                                        |
-| dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                                      |
+| transparent              | `false`  | Enable this to disable setting the background color                                                                                                                               |
 | transparent_sidebar      | `false`  | Sidebar like windows like `NvimTree` get a transparent background                                                                                                                 |
-| dark_float               | `true`   | Float windows like the lsp diagnostics windows get a darker background.                                                                                                           |
-| colors                   | `{}`     | You can override specific color groups to use other groups or a hex color                                                                                                         |
+| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                                          |
 
 ```vim
 " Example config in VimScript

--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -129,6 +129,12 @@ function M.setup(config)
   colors.bg_float = config.dark_float and colors.bg2 or colors.bg
   colors.fg_sidebar = colors.fg_dark
 
+  -- EndOfBuffer
+  colors.sidebar_eob = config.dark_sidebar and colors.bg2 or colors.bg
+  colors.sidebar_eob = config.hide_end_of_buffer and colors.sidebar_eob or
+                           colors.fg_gutter
+  colors.eob = config.hide_end_of_buffer and colors.bg or colors.fg_gutter
+
   -- LineNumber
   colors.bg_linenumber = config.highlight_linenumber and colors.bg2 or colors.bg
   colors.fg_linenumber = colors.fg_gutter

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -26,22 +26,23 @@ end
 
 ---@class onedark.Config
 local config = {
-  transparent = opt("transparent", false),
-  comment_style = opt("comment_style", "italic"),
-  keyword_style = opt("keyword_style", "italic"),
-  function_style = opt("function_style", "italic"),
-  variable_style = opt("variable_style", "NONE"),
-  msg_area_style = opt("msg_area_style", "NONE"),
-  lualine_bold = opt("lualine_bold", false),
-  hide_inactive_statusline = opt("hide_inactive_statusline", false),
-  highlight_linenumber = opt("highlight_linenumber", false),
-  sidebars = opt("sidebars", {}),
   colors = opt("colors", {}),
-  dev = opt("dev", false),
+  comment_style = opt("comment_style", "italic"),
   dark_float = opt("dark_float", true),
   dark_sidebar = opt("dark_sidebar", true),
+  dev = opt("dev", false),
+  function_style = opt("function_style", "italic"),
+  hide_end_of_buffer = opt("hide_end_of_buffer", true),
+  hide_inactive_statusline = opt("hide_inactive_statusline", false),
+  highlight_linenumber = opt("highlight_linenumber", false),
+  keyword_style = opt("keyword_style", "italic"),
+  lualine_bold = opt("lualine_bold", false),
+  msg_area_style = opt("msg_area_style", "NONE"),
+  sidebars = opt("sidebars", {}),
+  transform_colors = false,
+  transparent = opt("transparent", false),
   transparent_sidebar = opt("transparent_sidebar", false),
-  transform_colors = false
+  variable_style = opt("variable_style", "NONE")
 }
 
 --- @param user_config onedark.Config

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -29,7 +29,7 @@ function M.setup(config)
     DiffChange = {fg = c.git.change, bg = c.diff.change}, -- diff mode: Changed line |diff.txt|
     DiffDelete = {fg = c.git.delete, bg = c.diff.delete}, -- diff mode: Deleted line |diff.txt|
     DiffText = {bg = c.diff.text}, -- diff mode: Changed text within a changed line |diff.txt|
-    EndOfBuffer = {fg = c.bg}, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+    EndOfBuffer = {fg = c.eob}, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = {fg = c.error}, -- error messages on the command line
@@ -49,7 +49,7 @@ function M.setup(config)
     MsgArea = {fg = c.fg_dark, style = config.msg_area_style}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     MoreMsg = {fg = c.blue}, -- |more-prompt|
-    NonText = {fg = c.bg}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+    NonText = {fg = c.eob}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
     Normal = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text
     NormalNC = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text in non-current windows
     NormalSB = {fg = c.fg_sidebar, bg = c.bg_sidebar}, -- normal text in non-current windows
@@ -272,11 +272,11 @@ function M.setup(config)
 
     -- markdown
     TSURI = {fg = c.blue, style = "underline"},
-    TSLiteral = { fg = c.red },
-    TSTextReference = { fg = c.blue },
+    TSLiteral = {fg = c.red},
+    TSTextReference = {fg = c.blue},
     TSTitle = {fg = c.red, style = "bold"},
-    TSEmphasis = { style = "italic" },
-    TSStrong = { style = "bold" },
+    TSEmphasis = {style = "italic"},
+    TSStrong = {style = "bold"},
 
     -- php
     phpTSPunctBracket = {fg = c.syntax.php.punct_bracket},
@@ -372,7 +372,7 @@ function M.setup(config)
 
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},
-    NvimTreeEndOfBuffer = {fg = c.bg_sidebar},
+    NvimTreeEndOfBuffer = {fg = c.sidebar_eob},
     NvimTreeRootFolder = {fg = c.fg_light, style = "bold", bg = c.bg_sidebar},
     NvimTreeGitDirty = {fg = c.yellow2},
     NvimTreeGitNew = {fg = c.git.add},


### PR DESCRIPTION
### Default Value 
 `true`

### Preview
#### `hide_end_of_buffer` = false
```lua
require("onedark").setup({
  hide_end_of_buffer = false,
})
```
```vim
let g:onedark_hide_end_of_buffer = 0
colorscheme onedark
```
![image](https://user-images.githubusercontent.com/24286590/146674041-33811595-508b-4427-91ae-b2a118e5a4ce.png)

#### `hide_end_of_buffer` = true
```lua
require("onedark").setup({
  hide_end_of_buffer = true,
})
```
```vim
let g:onedark_hide_end_of_buffer = 1
colorscheme onedark
```
![image](https://user-images.githubusercontent.com/24286590/146674139-e69381e0-b743-4a6c-8f7b-add3d3536819.png)

### Other Changes
- config options are sorted in `README.md` and `theme.lua` files.