### PR TITLE
feat: allow customizing highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ require('lualine').setup {
 | keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                                           |
 | lualine_bold             | `false`  | When `true`, section headers in the lualine theme will be bold                                                                                                                    |
 | msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                                               |
+| overrides                | `function` | Override specific highlight groups. The function accpet colors as argument.                                                              |
 | sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                                        |
 | transparent              | `false`  | Enable this to disable setting the background color                                                                                                                               |
 | transparent_sidebar      | `false`  | Sidebar like windows like `NvimTree` get a transparent background                                                                                                                 |
@@ -148,7 +149,16 @@ require("onedark").setup({
   sidebars = {"qf", "vista_kind", "terminal", "packer"},
 
   -- Change the "hint" color to the "orange" color, and make the "error" color bright red
-  colors = {hint = "orange", error = "#ff0000"}
+  colors = {hint = "orange", error = "#ff0000"},
+  -- Overwrite the highlight groups
+  overrides = function(c)
+    return {
+      htmlTag = {fg = c.red, bg = "#282c34", sp = c.hint, style = "underline"},
+      DiagnosticHint = {link = "LspDiagnosticsDefaultHint"},
+      -- this will remove the highlight groups
+      TSField = {},
+    }
+  end
 })
 ```
 

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -38,6 +38,7 @@ local config = {
   keyword_style = opt("keyword_style", "italic"),
   lualine_bold = opt("lualine_bold", false),
   msg_area_style = opt("msg_area_style", "NONE"),
+  overrides = opt("overrides", function() return {} end),
   sidebars = opt("sidebars", {}),
   transform_colors = false,
   transparent = opt("transparent", false),

--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -4,6 +4,14 @@ local config_module = require("onedark.config")
 
 local M = {}
 
+local function apply_overrides(group, overrides)
+  for k, v in pairs(overrides) do
+    if group[k] ~= nil and type(v) == "table"  then
+      group[k] = v
+    end
+  end
+end
+
 ---@param config onedark.Config
 ---@return onedark.Theme
 function M.setup(config)
@@ -587,6 +595,11 @@ function M.setup(config)
   }
 
   theme.defer = {}
+
+  local overrides = config.overrides(c)
+  apply_overrides(theme.base, overrides)
+  apply_overrides(theme.plugins, overrides)
+  apply_overrides(theme.defer, overrides)
 
   if config.hide_inactive_statusline then
 

--- a/lua/onedark/util.lua
+++ b/lua/onedark/util.lua
@@ -77,6 +77,10 @@ end
 
 -- local ns = vim.api.nvim_create_namespace("onedark")
 function util.highlight(group, color)
+  if not (color.fg or color.bg or color.sp or color.style or color.link) then
+    return
+  end
+
   if color.fg then util.colorsUsed[color.fg] = true end
   if color.bg then util.colorsUsed[color.bg] = true end
   if color.sp then util.colorsUsed[color.sp] = true end


### PR DESCRIPTION
Related: #70 

Add setup option to overwrite the highlight group.  Although the group can be overwritten by `defer_fn` hack currently, the method will cause flicker of colors on startup because the highlight groups are specified twice. Allowing user to directly overwrite the definition will address this problem.