### PR TITLE
Update lua TS query for upstream parser change

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -1,1 +1,1 @@
-(self) @variable.builtin
+@variable.builtin


### PR DESCRIPTION
nvim-treesitter has switched to a new Lua parser (https://github.com/nvim-treesitter/nvim-treesitter/commit/c80715f883b8c7963782973b23297c5dec7924be, https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1015846555) and the query in this plugin needs updating.