### PR TITLE
Fix indent guides being italic on commented lines

### DIFF
--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -557,6 +557,9 @@ theme.setup = function(cfg)
 
     CocHighlightText = { link = 'Visual' },
     CocUnderline = { style = 'undercurl' },
+
+    -- Indent blankline
+    IndentBlanklineChar = {fg = c.bg_visual, style = 'nocombine'},
   }
 
   if cfg.hide_inactive_statusline then


### PR DESCRIPTION
If `comment_style = italic` the characters from indent-blankline.nvim would get italicized as well on commented and indented lines, as described in [this issue](https://github.com/lukas-reineke/indent-blankline.nvim/issues/72)