### PR TITLE
feat: added Purescript theme support

### DIFF
--- a/lua/onedark/theme.lua
+++ b/lua/onedark/theme.lua
@@ -316,6 +316,23 @@ theme.setup = function(cfg)
     typescriptTSProperty = { fg = c.red0 },
     typescriptTSVariable = { fg = c.yellow1 },
 
+    -- purescript
+    purescriptModule = { fg = c.blue0 },
+    purescriptModuleKeyword = { fg = c.purple0},
+    purescriptWhere = { fg = c.purple0},
+    purescriptImport = { fg = c.blue0 },
+    purescriptImportAs = { fg = c.blue0 },
+    purescriptConstructor = { fg = c.red0 },
+    purescriptTypeVar = { fg = c.orange0 },
+    purescriptType = { fg = c.yellow1},
+    purescriptStructure = { fg = c.purple0},
+    purescriptOperator = { fg = c.cyan0},
+    purescriptOperatorType = { fg = c.cyan0},
+    purescriptAsKeyword = { fg = c.purple0},
+    purescriptImportKeyword = { fg = c.purple0},
+    purescriptImportParams = { fg = c.cyan0 },
+    purescriptDelimiter = { fg = c.cyan0 },
+
     -- xml
     xmlAttrib = { fg = c.red0 },
     xmlTag = { fg = c.fg0 },


### PR DESCRIPTION
Hi @ful1e5 

I have added purescript support for the theme

need your help with filetype based highlight group for **MatchParen**, can you please suggest how I can add
`MatchParen = { fg = c.cyan0, bg = c.bg_visual, style = Styles.Bold },` only for purescript filetype 


![Screenshot from 2022-06-01 00-36-17](https://user-images.githubusercontent.com/29101603/171267398-f38c87aa-7015-4a50-ae97-ad78d8d6a033.png)
![Screenshot from 2022-06-01 00-37-02](https://user-images.githubusercontent.com/29101603/171267420-671cc580-0a5e-48cb-a6a0-27a1f45e8c18.png)

Screenshots with MatchParen for PS

![Screenshot from 2022-06-01 00-41-37](https://user-images.githubusercontent.com/29101603/171267426-a0f5cb4f-f07f-47a1-bb9d-cdac88dfb2b4.png)
![Screenshot from 2022-06-01 00-41-46](https://user-images.githubusercontent.com/29101603/171267429-43a108af-d9ae-424d-ba17-6c37fa160a44.png)

